### PR TITLE
Minor typo

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/node.py
+++ b/components/tools/OmeroPy/src/omero/plugins/node.py
@@ -75,9 +75,9 @@ class NodeControl(BaseControl):
         try:
             command = ["icegridnode", self._icecfg()]
             if self._isWindows():
-                command = command + ["--install", "OMERO."+args.node]
+                command = command + ["--install", "OMERO."+args.name]
                 self.ctx.call(command)
-                self.ctx.call(["icegridnode", "--start", "OMERO."+args.node])
+                self.ctx.call(["icegridnode", "--start", "OMERO."+args.name])
             else:
                 command = command + ["--daemon", "--pidfile",
                                      str(self._pid()), "--nochdir"]


### PR DESCRIPTION
Affects the `bin\omero node NODENAME start` command, now working under Windows too.
